### PR TITLE
Revision 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typemap",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod",
   "author": "sinclairzx81",
   "license": "MIT",

--- a/src/typebox/typebox.ts
+++ b/src/typebox/typebox.ts
@@ -35,13 +35,14 @@ import * as t from '@sinclair/typebox'
 
 /** Creates a TypeBox type from Syntax or another Type */
 // prettier-ignore
-export type TTypeBox<Type extends object | string> = (
+export type TTypeBox<Type extends object | string, Result = (
   Guard.TIsSyntax<Type> extends true ? TTypeBoxFromSyntax<Type> :
   Guard.TIsTypeBox<Type> extends true ? TTypeBoxFromTypeBox<Type> :
   Guard.TIsValibot<Type> extends true ? TTypeBoxFromValibot<Type> :
   Guard.TIsZod<Type> extends true ? TTypeBoxFromZod<Type> :
   t.TNever
-)
+)> = Result
+
 /** Creates a TypeBox type from Syntax or another Type */
 // prettier-ignore
 export function TypeBox<Type extends object | string>(type: Type): TTypeBox<Type> {
@@ -58,6 +59,6 @@ export function TypeBox<Type extends object | string>(type: Type): TTypeBox<Type
  * Creates a TypeBox type from Syntax or another Type
  * @deprecated Use TypeBox() export instead
  */
-export function Box<Type extends object | string>(type: Type): TTypeBox<Type> {
-  return TypeBox(type)
+export function Box<Type extends object | string, Mapped = TTypeBox<Type>, Result extends Mapped = Mapped>(type: Type): Result {
+  return TypeBox(type) as never
 }

--- a/src/valibot/valibot.ts
+++ b/src/valibot/valibot.ts
@@ -36,16 +36,16 @@ import * as c from './common'
 
 /** Creates a Valibot type from Syntax or another Type */
 // prettier-ignore
-export type TValibot<Type extends object | string> = (
+export type TValibot<Type extends object | string, Result = (
   Guard.TIsSyntax<Type> extends true ? TValibotFromSyntax<Type> :
   Guard.TIsTypeBox<Type> extends true ? TValibotFromTypeBox<Type> :
   Guard.TIsValibot<Type> extends true ? TValibotFromValibot<Type> :
   Guard.TIsZod<Type> extends true ? TValibotFromZod<Type> :
   v.NeverSchema<c.BaseError>
-)
+)> = Result
 /** Creates a Valibot type from Syntax or another Type */
 // prettier-ignore
-export function Valibot<Type extends object | string, Result = TValibot<Type>>(type: Type): Result {
+export function Valibot<Type extends object | string, Mapped = TValibot<Type>, Result extends Mapped = Mapped>(type: Type): Result {
   return (
     Guard.IsSyntax(type) ? ValibotFromSyntax(type) :
     Guard.IsTypeBox(type) ? ValibotFromTypeBox(type) :

--- a/src/zod/zod.ts
+++ b/src/zod/zod.ts
@@ -35,17 +35,17 @@ import * as z from 'zod'
 
 /** Creates a Zod type from Syntax or another Type */
 // prettier-ignore
-export type TZod<Type extends object | string> = (
+export type TZod<Type extends object | string, Result = (
   Guard.TIsSyntax<Type> extends true ? TZodFromSyntax<Type> :
   Guard.TIsTypeBox<Type> extends true ? TZodFromTypeBox<Type> :
   Guard.TIsValibot<Type> extends true ? TZodFromValibot<Type> :
   Guard.TIsZod<Type> extends true ? TZodFromZod<Type> :
   z.ZodNever
-)
+)> = Result
 
 /** Creates a Zod type from Syntax or another Type */
 // prettier-ignore
-export function Zod<Type extends object | string, Result = TZod<Type>>(type: Type): Result {
+export function Zod<Type extends object | string, Mapped = TZod<Type>, Result extends Mapped = Mapped>(type: Type): Result {
   return (
     Guard.IsSyntax(type) ? ZodFromSyntax(type) : 
     Guard.IsTypeBox(type) ? ZodFromTypeBox(type) : 


### PR DESCRIPTION
This PR applies a update to ensure type evaluation occurs at the library mapping signatures. This resolves a TS issue where mapped types may be resolve when embedded in library types. Noted for Valibot union.

```typescript
import { TypeBox, Valibot, Zod } from '@sinclair/typemap'
import { Parse } from '@sinclair/typebox/value'

import * as t from '@sinclair/typebox'
import * as v from 'valibot'
import * as z from 'zod'

// Valibot Type with Embedded TypeBox, Zod and Syntax types.
const T = v.union([
  v.literal('valibot'),           // native
  Valibot(t.Literal('typebox')),  // embedded
  Valibot(z.literal('zod')),      // embedded
  Valibot('"syntax"')             // parsed
])

// ... parse via Valibot
const R1 = v.parse(T, '...')

// ... or parse via Zod
const R2 = Zod(T).parse('...')

// ... or parse via TypeBox
const R3 = Parse(TypeBox(T), '...')
```