### PR TITLE
Revision 0.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typemap",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod",
   "author": "sinclairzx81",
   "license": "MIT",

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -82,6 +82,10 @@ export class Validator<Type extends t.TSchema> implements StandardSchemaV1<Type,
   public get ['~standard'](): StandardSchemaProps<Type> {
     return this.#standard
   }
+  /** Returns the code used by this validator. */
+  public Code(): string {
+    return this.#check.Code()
+  }
   /** Parses this value. Do not use this function for high throughput validation */
   public Parse(value: unknown): t.StaticDecode<Type> {
     return Value.Parse(this.#check.Schema(), value)


### PR DESCRIPTION
This PR makes the Compiler JIT code accessible via the Validator.

```typescript
const code = Compile('string').Code()
```