### PR TITLE
Revision 0.8.6

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { TypeBox, Valibot, Zod } from '@sinclair/typemap'
+import { TypeBox, Valibot, Zod, Compile, Static } from '@sinclair/typemap'
 
 // Parse Syntax | Parse Value 
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { TypeBox, Valibot, Zod, Compile, Static } from '@sinclair/typemap'
+import { TypeBox, Valibot, Zod } from '@sinclair/typemap'
 
 // Parse Syntax | Parse Value 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typemap",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.5",
-  "description": "Unified Syntax and Type Compiler for Runtime Type Systems",
+  "version": "0.8.6",
+  "description": "Unified Syntax and Type Compiler for Runtime Types",
   "author": "sinclairzx81",
   "license": "MIT",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,9 @@ const result = Compile('string | null').Parse('Hello World')
 
 ## Overview
 
-TypeMap is a syntax frontend and compiler backend for the [TypeBox](https://github.com/sinclairzx81/typebox), [Valibot](https://github.com/fabian-hiller/valibot) and [Zod](https://github.com/colinhacks/zod) type libraries. It provides a common TypeScript syntax for type construction, a runtime compiler for high-performance validation and enables types written in one library to be translated to another. 
+TypeMap is a syntax frontend and compiler backend for the [TypeBox](https://github.com/sinclairzx81/typebox), [Valibot](https://github.com/fabian-hiller/valibot) and [Zod](https://github.com/colinhacks/zod) type libraries. It provides a common TypeScript syntax for type construction, a runtime compiler for high-performance validation and provides type translation from one library to another.
 
-TypeMap is built as an advanced adapter and integration system for the TypeBox project. It is designed to integrate and accelerate remote libraries by mapping them to TypeBox and Json Schema compatible infrastructure as well as allowing TypeBox to integrate on Zod specific infrastructure via reverse type mapping. This library is also written to offer high-performance validation for systems that orientate around the [Standard Schema](https://github.com/standard-schema/standard-schema) TypeScript interface.
+TypeMap is built as an advanced adapter and integration mechanism for the TypeBox project. It is designed to integrate and accelerate remote libraries by mapping them to TypeBox and Json Schema compatible infrastructure as well as allowing TypeBox to integrate on Zod specific infrastructure via reverse type mapping. This library is also written to offer high-performance validation for systems that orientate around the [Standard Schema](https://github.com/standard-schema/standard-schema) TypeScript interface.
 
 License: MIT
 
@@ -147,7 +147,7 @@ const R = C.Check({                                 // Iterations: 10_000_000
 
 ## Mapping
 
-TypeMap is principally a runtime mapping library used for type translation. It provides a mapping function for each translatable library which is used to translate types and schematics into that library. If no translation is possible, these functions return a never representation specific to the library being mapped.
+TypeMap is principally a runtime mapping library used for type translation. It provides a mapping function per translatable library which is used to map remote types and schematics into that library. If no translation is possible, these functions return a never representation specific to the library being mapped.
 
 ### TypeBox
 
@@ -174,7 +174,6 @@ const S = Valibot('string[]')                       // const S: v.ArraySchema<..
 const T = Valibot(t.Number())                       // const T: v.NumberSchema     (TypeBox)
 const V = Valibot(v.string())                       // const V: v.StringSchema     (Valibot)
 const Z = Valibot(z.boolean())                      // const Z: v.BooleanSchema    (Zod)
-
 ```
 
 ### Zod
@@ -188,7 +187,6 @@ const S = Zod('string[]')                           // const S: z.ZodArray<...> 
 const T = Zod(t.Number())                           // const T: z.ZodNumber     (TypeBox)
 const V = Zod(v.string())                           // const V: z.ZodString     (Valibot)
 const Z = Zod(z.boolean())                          // const Z: z.ZodBoolean    (Zod)
-
 ```
 
 ## Syntax
@@ -289,26 +287,26 @@ type S = Static<typeof S>                           // string[]
 
 ## Compile
 
-Use Compile to build Zod and Valibot on TypeBox validation infrastructure. ([Example](https://www.typescriptlang.org/play/?moduleResolution=99&module=199#code/JYWwDg9gTgLgBAbzgYQuYAbApgGjgLQgBM4BfOAMyjTgHIABAZ2ADsBjDAQ2CgHoYAnmCwhOYWgCgJvXijRhMWOABUhWKWwgtG8AGpwAvHPTYAFISKmABgglx7ADwBccFgFcQAIyxQcd+wIu7l4+fvZwAF5BHt5QEqRWAJSJUjIqagCyYi7IABZYbADWcABibuwwwFpwpiWcOikSmtrwAEoAjIZwugB0eQWFpkjOcO14gXAATHhRcADMZI1pAMownCxEnFAky2z5oi66nBjAmzBKZRVVLDV1DRpaOnCtk126ANq0AH4665vbtAAuj0AG7HU6cc5DOAjMZwCbTSIuBakRJAA))
+Use the `Compile` function to compile Zod and Valibot on TypeBox validation infrastructure. ([Example](https://www.typescriptlang.org/play/?moduleResolution=99&module=199#code/JYWwDg9gTgLgBAbzgYQuYAbApgGjgLQgBM4BfOAMyjTgHIABAZ2ADsBjDAQ2CgHoYAnmCwhOYWgCgJvXijRhMWOABUhWKWwgtG8AGpwAvHPTYAFISKmABgglx7ADwBccFgFcQAIyxQcd+wIu7l4+fvZwAF5BHt5QEqRWAJSJUjIqagCyYi7IABZYbADWcABibuwwwFpwpiWcOikSmtrwAEoAjIZwugB0eQWFpkjOcO14gXAATHhRcADMZI1pAMownCxEnFAky2z5oi66nBjAmzBKZRVVLDV1DRpaOnCtk126ANq0AH4665vbtAAuj0AG7HU6cc5DOAjMZwCbTSIuBakRJAA))
 
 ```typescript
 import { Compile, Zod } from '@sinclair/typemap'
 
-// Compile Type
+// Compile Validator From Zod
 
-const V = Compile(Zod(`{
+const validator = Compile(Zod(`{
    x: number,
    y: number,
    z: number
 }`))
 
-// TypeMap: Check Function (Fast)
+const R1 = validator.Check({ x: 1, y: 2, z: 3 })
 
-const R1 = V.Check({ x: 1, y: 2, z: 3 })
+// Standard Schema
+//
+// ... which should have been named 'Standard Validator'
 
-// Standard Schema: Validate Function (Fast)
-
-const R2 = V['~standard'].validate({ x: 1, y: 2, z: 3 })
+const R2 = validator['~standard'].validate({ x: 1, y: 2, z: 3 })
 ```
 
 ## Benchmark

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -1,0 +1,99 @@
+/*--------------------------------------------------------------------------
+
+@sinclair/typemap
+
+The MIT License (MIT)
+
+Copyright (c) 2024-2025 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+import { TypeCheck, ValueErrorIterator } from '@sinclair/typebox/compiler'
+import { Value } from '@sinclair/typebox/value'
+import { StandardSchemaV1 } from './standard'
+import * as t from '@sinclair/typebox'
+
+// ------------------------------------------------------------------
+// StandardSchemaProps<Input, Output>
+// ------------------------------------------------------------------
+export class StandardSchemaProps<Type extends t.TSchema> implements StandardSchemaV1.Props<Type, t.Static<Type>> {
+  private readonly _check: TypeCheck<Type>
+  constructor(check: TypeCheck<Type>) {
+    this._check = check
+  }
+  // ----------------------------------------------------------------
+  // StandardSchemaV1.Props<Type, t.Static<Type>>
+  // ----------------------------------------------------------------
+  public get vendor(): '@sinclair/typemap' {
+    return '@sinclair/typemap'
+  }
+  public get version(): 1 {
+    return 1
+  }
+  public get types(): { input: Type; output: t.Static<Type> } {
+    return { input: this._check.Schema(), output: null }
+  }
+  public validate(value: unknown): StandardSchemaV1.Result<t.Static<Type>> {
+    return this._check.Check(value) ? this._createValue(value) : this._createIssues(value)
+  }
+  // ----------------------------------------------------------------
+  // Internal
+  // ----------------------------------------------------------------
+  private _createIssues(value: unknown) {
+    const errors = [...Value.Errors(this._check.Schema(), value)]
+    const issues: StandardSchemaV1.Issue[] = errors.map((error) => ({ ...error, path: [error.path] }))
+    return { issues }
+  }
+  private _createValue(value: unknown) {
+    return { value }
+  }
+}
+// ------------------------------------------------------------------
+// Validator<TSchema>
+// ------------------------------------------------------------------
+export class Validator<Type extends t.TSchema> implements StandardSchemaV1<Type, t.Static<Type>> {
+  private readonly _standard: StandardSchemaProps<Type>
+  private readonly _check: TypeCheck<Type>
+  constructor(check: TypeCheck<Type>) {
+    this._standard = new StandardSchemaProps<Type>(check)
+    this._check = check
+  }
+  /** Standard Schema Interface */
+  public get ['~standard'](): StandardSchemaProps<Type> {
+    return this._standard
+  }
+  /** Returns the code used by this validator. */
+  public Code(): string {
+    return this._check.Code()
+  }
+  /** Parses this value. Do not use this function for high throughput validation */
+  public Parse(value: unknown): t.StaticDecode<Type> {
+    return Value.Parse(this._check.Schema(), value)
+  }
+  /** Checks if this value matches the type */
+  public Check(value: unknown): value is t.Static<Type> {
+    return this._check.Check(value)
+  }
+  /** Returns errors for this value */
+  public Errors(value: unknown): ValueErrorIterator {
+    return this._check.Errors(value)
+  }
+}

--- a/src/static.ts
+++ b/src/static.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { Validator } from './compile/validator'
 import * as s from '@sinclair/typebox/syntax'
 import * as t from '@sinclair/typebox'
 import * as v from 'valibot'
@@ -37,6 +38,7 @@ type BaseSchema = v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>
 // prettier-ignore
 export type Static<Type extends object | string> = (
   Type extends string ? s.StaticParseAsType<{}, Type> :
+  Type extends Validator<infer Type extends t.TSchema> ? t.Static<Type> :
   Type extends t.TSchema ? t.Static<Type> : 
   Type extends BaseSchema ? v.InferInput<Type> : 
   Type extends z.ZodTypeAny ? z.infer<Type> :

--- a/src/typebox/typebox.ts
+++ b/src/typebox/typebox.ts
@@ -81,13 +81,13 @@ export function TypeBox<Type extends object | string>(type: Type, options?: TSyn
 // prettier-ignore
 export function TypeBox(...args: any[]): never {
   const [parameter, type, options] = g.Signature(args)
-  return t.CloneType(
+  return (
     t.ValueGuard.IsString(type) ? TypeBoxFromSyntax(ContextFromParameter(parameter), type, options) :
     g.IsTypeBox(type) ? TypeBoxFromTypeBox(type) :
     g.IsValibot(type) ? TypeBoxFromValibot(type) :
     g.IsZod(type) ? TypeBoxFromZod(type) :
-    t.Never(),
-  options) as never
+    t.Never()
+  ) as never
 }
 
 /** Creates a TypeBox type from Syntax or another Type */

--- a/test/compile.ts
+++ b/test/compile.ts
@@ -1,0 +1,39 @@
+import { Assert } from './assert'
+import { TypeBox, Valibot, Zod, Compile } from '@sinclair/typemap'
+
+describe('Compile', () => {
+  it('Should compile Syntax', () => {
+    const C = Compile('123')
+    Assert.IsTrue(C.Check(123))
+  })
+  it('Should compile Syntax (Parameterized)', () => {
+    const C = Compile({ T: TypeBox('123') }, 'T')
+    Assert.IsTrue(C.Check(123))
+  })
+  it('Should compile TypeBox', () => {
+    const C = Compile(TypeBox('123'))
+    Assert.IsTrue(C.Check(123))
+  })
+  it('Should compile TypeBox (Parameterized)', () => {
+    const C = Compile({ T: TypeBox('123') }, 'T')
+    Assert.IsTrue(C.Check(123))
+  })
+
+  it('Should compile Valibot', () => {
+    const C = Compile(Valibot('123'))
+    Assert.IsTrue(C.Check(123))
+  })
+  it('Should compile Valibot (Parameterized)', () => {
+    const C = Compile({ T: Valibot('123') }, 'T')
+    Assert.IsTrue(C.Check(123))
+  })
+
+  it('Should compile Zod', () => {
+    const C = Compile(Zod('123'))
+    Assert.IsTrue(C.Check(123))
+  })
+  it('Should compile Zod (Parameterized)', () => {
+    const C = Compile({ T: Zod('123') }, 'T')
+    Assert.IsTrue(C.Check(123))
+  })
+})

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,4 @@
+import './compile'
 import './options'
 import './parameters'
 import './typebox-from-zod'


### PR DESCRIPTION
This PR adds parameterized type support on Compile. It also fixes the inferred Validator type and adds Validate type inference support via Static.

```typescript
const T = Zod('number')

const C = Compile({ T }, '[T, T]') // Validator<TTuple<[TNumber, TNumber]>>
```