### PR TITLE
Revision 0.8.10

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,25 +1,37 @@
-import { TypeBox } from '@sinclair/typemap'
+import { TypeBox, Valibot, Zod, Syntax, Compile } from '@sinclair/typemap'
 
-import * as z from 'zod'
+// ------------------------------------------------------------------
+// Syntax Types
+// ------------------------------------------------------------------
 
-const Z = z.object({                                // const Z: z.ZodObject<{
-  x: z.number(),                                    //   x: z.ZodNumber;
-  y: z.number(),                                    //   y: z.ZodNumber;
-  z: z.number()                                     //   z: z.ZodNumber;
-}).strict()                                         // }, "strict", ...>
+const S = `{
+  x: number,
+  y: number,
+  z: number
+}`
 
-// TypeBox represents types as Json Schema
+// ------------------------------------------------------------------
+// Runtime Types
+// ------------------------------------------------------------------
 
-const T = TypeBox(Z)                                // const T = {
-                                                    //   type: 'object',
-                                                    //   required: ['x', 'y', 'z'],
-                                                    //   additionalProperties: false,
-                                                    //   properties: {
-                                                    //     x: { type: 'number' },
-                                                    //     y: { type: 'number' },
-                                                    //     z: { type: 'number' }
-                                                    //   }
-                                                    // }
+const T = TypeBox(S)                                // const T: TObject<{ ... }>
 
+const V = Valibot(S)                                // const V: ObjectSchema<{ ... }, ...>
 
-console.log(T)
+const Z = Zod(S)                                    // const Z: ZodObject<{ ... }, ...>
+
+// ------------------------------------------------------------------
+// Reverse Syntax
+// ------------------------------------------------------------------
+
+const X = Syntax(Z)                                 // const X: "{ x: number, y: number, z: number }"
+
+// ------------------------------------------------------------------
+// Compile
+// ------------------------------------------------------------------
+
+const C = Compile(X)                                // const C: Validator<TObject<{
+                                                    //  x: TNumber;
+                                                    //  y: TNumber;
+                                                    //  z: TNumber;
+                                                    // }>>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typemap",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typemap",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Syntax, Compiler and Translation System for Runtime Types",
   "author": "sinclairzx81",
   "license": "MIT",

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -34,7 +34,7 @@ import * as t from '@sinclair/typebox'
 // ------------------------------------------------------------------
 // StandardSchemaProps<Input, Output>
 // ------------------------------------------------------------------
-export class StandardSchemaProps<Type extends t.TSchema> implements StandardSchemaV1.Props<Type, t.Static<Type>> {
+export class StandardSchemaProps<Type extends t.TSchema> implements StandardSchemaV1.Props<t.Static<Type>, t.Static<Type>> {
   private readonly _check: TypeCheck<Type>
   constructor(check: TypeCheck<Type>) {
     this._check = check
@@ -48,11 +48,11 @@ export class StandardSchemaProps<Type extends t.TSchema> implements StandardSche
   public get version(): 1 {
     return 1
   }
-  public get types(): { input: Type; output: t.Static<Type> } {
-    return { input: this._check.Schema(), output: null }
+  public get types(): { input: t.Static<Type>; output: t.Static<Type> } {
+    throw Error('types is a phantom property used for inference only.')
   }
   public validate(value: unknown): StandardSchemaV1.Result<t.Static<Type>> {
-    return this._check.Check(value) ? this._createValue(value) : this._createIssues(value)
+    return (this._check.Check(value) ? this._createValue(value) : this._createIssues(value)) as never
   }
   // ----------------------------------------------------------------
   // Internal
@@ -69,7 +69,7 @@ export class StandardSchemaProps<Type extends t.TSchema> implements StandardSche
 // ------------------------------------------------------------------
 // Validator<TSchema>
 // ------------------------------------------------------------------
-export class Validator<Type extends t.TSchema> implements StandardSchemaV1<Type, t.Static<Type>> {
+export class Validator<Type extends t.TSchema> implements StandardSchemaV1<t.Static<Type>, t.Static<Type>> {
   private readonly _standard: StandardSchemaProps<Type>
   private readonly _check: TypeCheck<Type>
   constructor(check: TypeCheck<Type>) {

--- a/test/compile.ts
+++ b/test/compile.ts
@@ -2,6 +2,9 @@ import { Assert } from './assert'
 import { TypeBox, Valibot, Zod, Compile } from '@sinclair/typemap'
 
 describe('Compile', () => {
+  // ----------------------------------------------------------------
+  // Validator
+  // ----------------------------------------------------------------
   it('Should compile Syntax', () => {
     const C = Compile('123')
     Assert.IsTrue(C.Check(123))
@@ -18,7 +21,6 @@ describe('Compile', () => {
     const C = Compile({ T: TypeBox('123') }, 'T')
     Assert.IsTrue(C.Check(123))
   })
-
   it('Should compile Valibot', () => {
     const C = Compile(Valibot('123'))
     Assert.IsTrue(C.Check(123))
@@ -27,7 +29,6 @@ describe('Compile', () => {
     const C = Compile({ T: Valibot('123') }, 'T')
     Assert.IsTrue(C.Check(123))
   })
-
   it('Should compile Zod', () => {
     const C = Compile(Zod('123'))
     Assert.IsTrue(C.Check(123))
@@ -35,5 +36,20 @@ describe('Compile', () => {
   it('Should compile Zod (Parameterized)', () => {
     const C = Compile({ T: Zod('123') }, 'T')
     Assert.IsTrue(C.Check(123))
+  })
+  // ----------------------------------------------------------------
+  // Standard Schema
+  // ----------------------------------------------------------------
+  it('Should validate via Standard Schema interface (Success)', () => {
+    const C = Compile('string')
+    const R = C['~standard'].validate('hello')
+    // @ts-ignore
+    Assert.IsEqual(R.value, 'hello') // Reference spec interface is broken here, It's not for me to fix.
+  })
+  it('Should validate via Standard Schema interface (Failure)', () => {
+    const C = Compile('string')
+    const R = C['~standard'].validate(12345)
+    Assert.IsTrue('issues' in R)
+    Assert.IsTrue(R.issues!.length > 0)
   })
 })


### PR DESCRIPTION
This PR applies a update to the Standard Schema Input / Output types. Downstream infrastructures (namely tRPC) infer client parameter structures from the interface, where as previously the Input was represented as a TSchema type.

```typescript
import { initTRPC } from '@trpc/server'
import { Compile as c } from '@sinclair/typemap'

const t = initTRPC.create()

const appRouter = t.router({
  add: t.procedure
    .input(c(`{ x: number, y: number }`)['~standard'])
    .output(c('number')['~standard'])
    .query(({input}) => {
      const { x, y } = input
      return x + y;
    }),
})


import { createTRPCProxyClient } from '@trpc/client';

const client = createTRPCProxyClient <typeof appRouter>({} as never);

client.add.query({ x: 1, y: 2 }) // fixes this
```